### PR TITLE
Update Cargo.toml repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uq"
 version = "0.1.2"
 authors = ["Tamir Bahar"]
-homepage = "https://github.com/lostutils/uq"
+repository = "https://github.com/lostutils/uq"
 license = "MIT"
 description = "sort | uniq alternative."
 readme = "README.md"


### PR DESCRIPTION
This is just a small adjustment to make the crate more predictable. The `homepage` field is intended for a dedicated website of the project if it exists, whereas the `repository` field is more suitable for a link to the respective GitHub repository.

You may also wish to have a look at the [C-METADATA](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#c-metadata) guideline for more information.

Congratulations on your first Rust crate. :+1: